### PR TITLE
Update the fabric-slack hook to match new Slack webhook API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,24 @@ Easily send messages during your deployments or any other Fabric command using s
 ## Installation
 * `pip install fabric-slack-tools`
 
+## Slack webhook setup
+Create an incoming webhook on Slack integration configuration. There, you will be asked which user to post as and which
+channel to announce to. This means you only need send data to the webhook URL, no need for any other configuration
+on client side other than the URL itself and the message to announce
+
 ## Example fabfile
 ```python
 from fabric.api import *
 from fabric_slack_tools import *
 
 def do_build():
-    send_slack_message("This is the text", channel="#mychannel", username="TheBot")
+    send_slack_message("This is the text")
 
 @roles("webserver")
-@announce_deploy("MyProject", channel="builds", username="MyBuildBot")
+@announce_deploy("MyProject")
 def deploy_server():
     run("do something")
 
 
-init_slack("https://examplecorp.slack.com/services/hooks/incoming-webhook?token=xxxxxxxxxxx")
+init_slack("https://hooks.slack.com/services/XXXXXXXXX/YYYYYYYYY/ZZZZZZZZZZZZZZZZZZZZZZZZ")
 ```

--- a/fabric_slack_tools/__init__.py
+++ b/fabric_slack_tools/__init__.py
@@ -76,14 +76,14 @@ def announce_deploy(project, web_hook_url=None):
         @functools.wraps(func)
         def inner_decorator(*args, **kwargs):
             # Get current time
-            n = datetime.datetime.utcnow()
-
+            deploy_start = datetime.datetime.utcnow()
             # Get user's identity from a environment variable SLACK_IDENTITY, otherwise just get the default username
             deployment_handler = os.environ.get('SLACK_IDENTITY', getpass.getuser())
+            # Send a message on deployment start...
             send_slack_message("%s deploy started by %s on %s" % (project, deployment_handler, env.host), web_hook_url)
             return_value = func(*args, **kwargs)
-            send_slack_message("%s deploy ended by %s on %s. Took: %s" % (project, getpass.getuser(), env.host, str(datetime.datetime.utcnow() - n)))
-
+            # ... and upon finish
+            send_slack_message("%s deploy ended by %s on %s. Took: %s" % (project, getpass.getuser(), env.host, str(datetime.datetime.utcnow() - deploy_start)))
             return return_value
         return inner_decorator
     return real_announce_deploy

--- a/fabric_slack_tools/__init__.py
+++ b/fabric_slack_tools/__init__.py
@@ -25,6 +25,7 @@ import functools
 import urllib2
 import datetime
 import getpass
+import os
 try:
     import simplejson as json
 except ImportError:
@@ -38,7 +39,7 @@ def init_slack(web_hook_url):
     global _web_hook_url
     _web_hook_url = web_hook_url
 
-def send_slack_message(text, channel, username="SlackMessageBot", web_hook_url=None):
+def send_slack_message(text, web_hook_url=None):
     """
     send_slack_message - allow sending a slack message to a channel via a webhook.
     To configure a web hook:
@@ -46,6 +47,8 @@ def send_slack_message(text, channel, username="SlackMessageBot", web_hook_url=N
     - Copy the hook URL and use it via the web_hook_url function parameter or globally
       (so you won't have to repeat it) by calling init_slack once at the bottom
       of your fabfile
+    - There is no longer need to worry about channel or username since the Slack
+      incoming hook has already taken care of it on Slack's side
     """
     global _web_hook_url
 
@@ -55,20 +58,15 @@ def send_slack_message(text, channel, username="SlackMessageBot", web_hook_url=N
         else:
             raise ValueError("web_hook_url must be set")
 
-    if channel is None:
-        raise ValueError("channel must be set")
-
     data = {
-        "text" : text,
-        "channel" : channel,
-        "username" : username
+        "text" : text
     }
 
     req = urllib2.Request(web_hook_url)
     req.add_header("Content-Type", "application/json")
     urllib2.urlopen(req, json.dumps(data))
 
-def announce_deploy(project, channel="#ops", username="DeployBot", web_hook_url=None):
+def announce_deploy(project, web_hook_url=None):
     """
     announce_deploy - a decorator to announces a new deploy of the specificed project start,
     who started it and when. Also sends a message when the deploy ends and how long it took.
@@ -77,10 +75,14 @@ def announce_deploy(project, channel="#ops", username="DeployBot", web_hook_url=
     def real_announce_deploy(func):
         @functools.wraps(func)
         def inner_decorator(*args, **kwargs):
+            # Get current time
             n = datetime.datetime.utcnow()
-            send_slack_message("%s deploy started by %s on %s" % (project, getpass.getuser(), env.host), channel, username, web_hook_url)
+
+            # Get user's identity from a environment variable SLACK_IDENTITY, otherwise just get the default username
+            deployment_handler = os.environ.get('SLACK_IDENTITY', getpass.getuser())
+            send_slack_message("%s deploy started by %s on %s" % (project, deployment_handler, env.host), web_hook_url)
             return_value = func(*args, **kwargs)
-            send_slack_message("%s deploy ended by %s on %s. Took: %s" % (project, getpass.getuser(), env.host, str(datetime.datetime.utcnow() - n)), channel, username)
+            send_slack_message("%s deploy ended by %s on %s. Took: %s" % (project, getpass.getuser(), env.host, str(datetime.datetime.utcnow() - n)))
 
             return return_value
         return inner_decorator


### PR DESCRIPTION
`channel` and `username` are now configured on Slack when creating the webhook
